### PR TITLE
Update from v0.11.0 to v0.11.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ about:
     By adding an anaconda-project.yml to a project directory, a single 
     anaconda-project runcommand will be able to set up all dependencies 
     and then launch the project.
-  doc_url: http://anaconda-project.readthedocs.io
+  doc_url: https://anaconda-project.readthedocs.io/en/latest/
   dev_url: https://github.com/Anaconda-Platform/anaconda-project
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,11 +24,11 @@ requirements:
   run:
     - anaconda-client
     - conda-pack
+    - jinja2
     - python
     - requests
     - ruamel_yaml
     - tornado >=4.2
-    - jinja2
     - tqdm
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ about:
     By adding an anaconda-project.yml to a project directory, a single 
     anaconda-project runcommand will be able to set up all dependencies 
     and then launch the project.
-  doc_url: https://anaconda-project.readthedocs.io/en/latest/
+  doc_url: https://anaconda-project.readthedocs.io/
   dev_url: https://github.com/Anaconda-Platform/anaconda-project
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.11.0" %}
+{% set version = "0.11.1" %}
 
 package:
   name: anaconda-project
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Anaconda-Platform/anaconda-project/archive/v{{ version }}.tar.gz
-  sha256: 3bd125bd210586fb4adf539493240d28de9bcb2bab81e35a4eb60f382b3cfe63
+  sha256: 87be4f0b3df3d920e210d68f485403ee0ec429d306efc220608d2b9549bfc092
 
 build:
   skip: true  # [py<36]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ about:
     By adding an anaconda-project.yml to a project directory, a single 
     anaconda-project runcommand will be able to set up all dependencies 
     and then launch the project.
-  doc_url: https://anaconda-project.readthedocs.io/
+  doc_url: https://anaconda-project.readthedocs.io
   dev_url: https://github.com/Anaconda-Platform/anaconda-project
 
 extra:


### PR DESCRIPTION
Update Anaconda Project from version 0.11.0 to version 0.11.1

Addresses Jira ticket [DSNC-5208](https://anaconda.atlassian.net/browse/DSNC-5208).

# Package Info

Home: https://github.com/Anaconda-Platform/anaconda-project/
Source: https://github.com/Anaconda-Platform/anaconda-project/archive/v0.11.1.tar.gz
Documentation: https://anaconda-project.readthedocs.io/en/latest/
Change log: https://github.com/Anaconda-Platform/anaconda-project/compare/v0.11.0...v0.11.1

# Actions

* Update to version v0.11.1
* Update documentation