### PR TITLE
Bump to 0.13.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - anaconda-project = anaconda_project.cli:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.12.0" %}
+{% set version = "0.13.2" %}
 
 package:
   name: anaconda-project
@@ -6,10 +6,11 @@ package:
 
 source:
   url: https://github.com/Anaconda-Platform/anaconda-project/archive/v{{ version }}.tar.gz
-  sha256: 2247b120171cdf5210dcebdc23c4b622e89ff9543908766f799b362761b81a34
+  sha256: c5244dc4a0eeb8e52214dd31c4b19a3ac89fa9c7fa3e999cfddaba68faabdfd9
 
 build:
   number: 0
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - anaconda-project = anaconda_project.cli:main
@@ -22,12 +23,14 @@ requirements:
   run:
     - anaconda-client
     - conda-pack
+    - entrypoints
     - jinja2
     - python
     - requests
     - ruamel.yaml >=0.15
     - tornado >=4.2
     - tqdm
+    - tomli  # [py<311]
 
 test:
   requires:


### PR DESCRIPTION
anaconda-project 0.13.2

**Destination channel:** defaults

### Links

- [PKG-15162](https://anaconda.atlassian.net/browse/PKG-15162) 
- [Upstream repository](https://github.com/anaconda/anaconda-project)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-project/compare/v0.12.0...v0.13.2)

### Explanation of changes:

Driving towards a stable, end-of-life state for this project:

- Final triage of user-submitted issues
- Refresh of the documentation (including and end of active development)
- Addition of support for conversion to Pixi

Ideally this should be noarch, but because of the tomli dependency, we're leaving it arch-specific until such time as we drop Python 3.10 from our build matrix. Once Python 3.11 becomes the supported minimum we could convert this to noarch


[PKG-15162]: https://anaconda.atlassian.net/browse/PKG-15162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ